### PR TITLE
Fix links in footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,11 +11,9 @@ footer_links:
   - title: Kitware
     url: 'https://kitware.com'
   - title: Privacy Policy
-    url: 'https://m.vtk.org/index.php/VTKM:Privacy_policy'
-  - title: Disclaimers
-    url: 'https://m.vtk.org/index.php/VTKM:General_disclaimer'
+    url: 'https://www.kitware.com/privacy/#privacy-policy'
   - title: Contact
-    url: '/contact'
+    url: 'https://www.kitware.com/contact-us/'
 
 defaults:
   - scope:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,13 +3,15 @@
       <div class="py-6">
         <p class="space-x-3">
           {% for link in site.footer_links %}
-            <a href="{{ link.url | prepend: site.baseurl }}" class="text-primary-400" target="_blank">{{ link.title }}</a>
+            <a href="{{ link.url }}" class="text-primary-400" target="_blank">{{ link.title }}</a>
           {% endfor %}
         </p>
       </div>
+      <!--
       <div class="py-6">
         {{ site.footer_license }}
       </div>
+      -->
     </div>
   </footer>
 


### PR DESCRIPTION
Make the links in the footer more or less match those for the
VTK page. These links go to Kitware, Inc. information (rather
than for VTK-m). Items that I did not see a ready entry for
I just removed.

Fixes #9