### PR TITLE
Add link to bib file

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -51,6 +51,7 @@ publications: true
 pubs_title: VTK-m Publications
 pubs_blurb: >-
   <p>Please use the first paper when referencing VTK-m in scientific publications.</p>
+  <p><small><a href="https://raw.githubusercontent.com/Kitware/vtkm-web/master/_publications/pubs.bib" target="_blank">bib file</a></small></p>
 
 ---
 


### PR DESCRIPTION
I've had at least one request for the bibtex for the main VTK-m
reference. Might as well share the entire .bib file.