### PR TITLE
Redirect old links to Doxygen docs to the new site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,4 +6,4 @@
   # Previously, Doxygen docs were hosted under "m.vtk.org/documentation/",
   # so provide a redirect to transition any old links
   from = "/documentation/*"
-  to = "https://docs-m.vtk.org/documentation/:splat"
+  to = "https://docs-m.vtk.org/:splat"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,9 @@
 [build]
   publish = "_site/"
   command = "npm run prod && jekyll build"
+
+[[redirects]]
+  # Previously, Doxygen docs were hosted under "m.vtk.org/documentation/",
+  # so provide a redirect to transition any old links
+  from = "/documentation/*"
+  to = "https://docs-m.vtk.org/documentation/:splat"


### PR DESCRIPTION
See the docs at:
* https://docs.netlify.com/routing/redirects/#syntax-for-the-netlify-configuration-file
* https://docs.netlify.com/routing/redirects/redirect-options/#splats
for syntax information about this change.