### PR TITLE
Correct mailing list link

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -13,7 +13,7 @@
       url: http://m.vtk.org/documentation/
       new_tab: true
     - name: Mailing List
-      url: http://vtk.org/mailman/listinfo/vtkm
+      url: http://public.kitware.com/mailman/listinfo/vtkm
       new_tab: true
     - name: Software Dependencies
       url: https://gitlab.kitware.com/vtk/vtk-m/blob/master/README.md#dependencies
@@ -28,5 +28,5 @@
     - name: Publications
       url: /#publications
 - name: Contact
-  url: https://vtk.org/mailman/listinfo/vtkm
+  url: https://public.kitware.com/mailman/listinfo/vtkm
   new_tab: true

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -32,7 +32,7 @@ resources:
     link: 'https://gitlab.kitware.com/vtk/vtk-m/blob/master/CONTRIBUTING.md'
   - name: Mailing List
     icon: ri-send-plane-fill
-    link: 'http://vtk.org/mailman/listinfo/vtkm'
+    link: 'http://public.kitware.com/mailman/listinfo/vtkm'
   - name: User Guide
     icon: ri-book-2-fill
     link: 'https://gitlab.kitware.com/vtk/vtk-m-user-guide/-/wikis/home'


### PR DESCRIPTION
The mailing list link has to be to
https://public.kitware.com/mailman/listinfo/vtkm. The previous
version sent users to http://vtk.org/mailman/listinfo/vtkm. That
site works for some things, but fails to let people subscribe.