### PR TITLE
Update second tutorial link

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -41,7 +41,7 @@ resources:
     link: 'http://m.vtk.org/documentation/'
   - name: Tutorial
     icon: ri-lightbulb-flash-fill
-    link: '/tutorial'
+    link: https://gitlab.kitware.com/vtk/vtk-m/-/tree/master/tutorial
   - name: VTK-m Assets
     icon: ri-database-line
     link: '/assets'


### PR DESCRIPTION
There was a second tutorial link on the web page that I missed with the last commit.